### PR TITLE
NONE Sync node modules to local

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,4 +40,3 @@ services:
       - 8082:8082
     volumes:
       - ./client:/app
-      - /app/node_modules


### PR DESCRIPTION
## Change Summary
Allows syncing of the node modules to the local when docker installs node dependencies so it can be read by the IDE