### PR TITLE
I171 include username in reset password email

### DIFF
--- a/client/src/components/LoginModal.vue
+++ b/client/src/components/LoginModal.vue
@@ -20,7 +20,7 @@
           </v-col>
           <v-spacer />
           <v-col cols="auto">
-            <v-btn variant="plain" @click="modalStore.close">
+            <v-btn variant="plain" @click="resetState(); modalStore.close()">
               <v-icon icon="mdi-close" size="32px" />
             </v-btn>
           </v-col>
@@ -215,13 +215,14 @@ const modalStore = useModalStore()
 const page = ref<1 | 2 | 3 | 4 | 5>(1)
 const isFullscreen = ref(false)
 
-const form = ref({
+const initialForm = ref({
   ...modalStore.computedFields,
   email: '',
   token: '',
   newPassword: '',
   confirmPassword: ''
 })
+const form = ref({...initialForm.value})
 
 const errors = ref({
   login: '',
@@ -229,10 +230,14 @@ const errors = ref({
   token: '',
   newPassword: ''
 })
-
 const required = (v: string) => !!v || 'Field is required'
 
 const isEmail = (candidate: string) => /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/.test(candidate)
+
+function resetState() {
+  Object.assign(form, initialForm)
+  page.value = 1
+}
 
 const submitForm = async () => {
   if (await userStore.loginUser(form.value.username, form.value.password)) modalStore.close()
@@ -301,4 +306,3 @@ watchEffect(async () => {
   }
 })
 </script>
-@/stores/modal

--- a/client/src/components/LoginModal.vue
+++ b/client/src/components/LoginModal.vue
@@ -20,13 +20,7 @@
           </v-col>
           <v-spacer />
           <v-col cols="auto">
-            <v-btn
-              variant="plain"
-              @click="
-                resetState(),
-                modalStore.close()
-              "
-            >
+            <v-btn variant="plain" @click="close">
               <v-icon icon="mdi-close" size="32px" />
             </v-btn>
           </v-col>
@@ -240,9 +234,10 @@ const required = (v: string) => !!v || 'Field is required'
 
 const isEmail = (candidate: string) => /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/.test(candidate)
 
-function resetState() {
+function close() {
   Object.assign(form, initialForm)
   page.value = 1
+  modalStore.close()
 }
 
 const submitForm = async () => {

--- a/client/src/components/LoginModal.vue
+++ b/client/src/components/LoginModal.vue
@@ -19,7 +19,7 @@
           </v-col>
           <v-spacer />
           <v-col cols="auto">
-            <v-btn variant="plain" @click="close">
+            <v-btn variant="plain" @click="modalStore.close">
               <v-icon icon="mdi-close" size="32px" />
             </v-btn>
           </v-col>
@@ -212,13 +212,12 @@ const modalStore = useModalStore()
 const page = ref<1 | 2 | 3 | 4 | 5>(1)
 const isFullscreen = ref(false)
 
-const initialForm = ref({
+const form = ref({
   email: '',
   token: '',
   newPassword: '',
   confirmPassword: ''
 })
-const form = ref({ ...initialForm.value })
 
 const errors = ref({
   login: '',
@@ -229,12 +228,6 @@ const errors = ref({
 const required = (v: string) => !!v || 'Field is required'
 
 const isEmail = (candidate: string) => /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/.test(candidate)
-
-function close() {
-  Object.assign(form, initialForm)
-  page.value = 1
-  modalStore.close()
-}
 
 const submitForm = async () => {
   if (await userStore.loginUser(modalStore.username, modalStore.password)) modalStore.close()

--- a/client/src/components/LoginModal.vue
+++ b/client/src/components/LoginModal.vue
@@ -20,7 +20,13 @@
           </v-col>
           <v-spacer />
           <v-col cols="auto">
-            <v-btn variant="plain" @click="resetState(); modalStore.close()">
+            <v-btn
+              variant="plain"
+              @click="
+                resetState()
+                modalStore.close()
+              "
+            >
               <v-icon icon="mdi-close" size="32px" />
             </v-btn>
           </v-col>
@@ -222,7 +228,7 @@ const initialForm = ref({
   newPassword: '',
   confirmPassword: ''
 })
-const form = ref({...initialForm.value})
+const form = ref({ ...initialForm.value })
 
 const errors = ref({
   login: '',

--- a/client/src/components/LoginModal.vue
+++ b/client/src/components/LoginModal.vue
@@ -23,7 +23,7 @@
             <v-btn
               variant="plain"
               @click="
-                resetState()
+                resetState(),
                 modalStore.close()
               "
             >

--- a/client/src/components/MileageModal.vue
+++ b/client/src/components/MileageModal.vue
@@ -43,7 +43,7 @@
               <v-row>
                 <v-col>
                   <div
-                    v-if="userStore.user.travelMethod === 'RUNNING'"
+                    v-if="userStore.user!.travelMethod === 'RUNNING'"
                     class="ma-0 pa-0"
                     id="runner"
                   >
@@ -58,7 +58,7 @@
                     />
                   </div>
                   <div
-                    v-if="userStore.user.travelMethod === 'WALKING'"
+                    v-if="userStore.user!.travelMethod === 'WALKING'"
                     id="walker"
                     class="ma-0 pa-0"
                   >
@@ -73,7 +73,7 @@
                     />
                   </div>
                   <div
-                    v-if="userStore.user.travelMethod === 'WHEELING'"
+                    v-if="userStore.user!.travelMethod === 'WHEELING'"
                     id="wheeler"
                     class="ma-0 pa-0"
                   >

--- a/client/src/components/MileageModal.vue
+++ b/client/src/components/MileageModal.vue
@@ -42,7 +42,11 @@
               </v-row>
               <v-row>
                 <v-col>
-                  <div v-if="userStore.user.travelMethod === 'RUNNING'" class="ma-0 pa-0" id="runner">
+                  <div
+                    v-if="userStore.user.travelMethod === 'RUNNING'"
+                    class="ma-0 pa-0"
+                    id="runner"
+                  >
                     <v-slider
                       v-model="mileage.kilometres"
                       color="secondaryGreen"
@@ -53,7 +57,11 @@
                       max="100"
                     />
                   </div>
-                  <div v-if="userStore.user.travelMethod === 'WALKING'" id="walker" class="ma-0 pa-0">
+                  <div
+                    v-if="userStore.user.travelMethod === 'WALKING'"
+                    id="walker"
+                    class="ma-0 pa-0"
+                  >
                     <v-slider
                       v-model="mileage.kilometres"
                       color="green"
@@ -64,7 +72,11 @@
                       max="100"
                     />
                   </div>
-                  <div v-if="userStore.user.travelMethod === 'WHEELING'" id="wheeler" class="ma-0 pa-0">
+                  <div
+                    v-if="userStore.user.travelMethod === 'WHEELING'"
+                    id="wheeler"
+                    class="ma-0 pa-0"
+                  >
                     <v-slider
                       v-model="mileage.kilometres"
                       color="green"

--- a/client/src/components/MileageModal.vue
+++ b/client/src/components/MileageModal.vue
@@ -42,7 +42,7 @@
               </v-row>
               <v-row>
                 <v-col>
-                  <div v-if="tempIconType === 'RUNNING'" class="ma-0 pa-0" id="runner">
+                  <div v-if="userStore.user.travelMethod === 'RUNNING'" class="ma-0 pa-0" id="runner">
                     <v-slider
                       v-model="mileage.kilometres"
                       color="secondaryGreen"
@@ -53,7 +53,7 @@
                       max="100"
                     />
                   </div>
-                  <div v-if="tempIconType === 'WALKING'" id="walker" class="ma-0 pa-0">
+                  <div v-if="userStore.user.travelMethod === 'WALKING'" id="walker" class="ma-0 pa-0">
                     <v-slider
                       v-model="mileage.kilometres"
                       color="green"
@@ -64,7 +64,7 @@
                       max="100"
                     />
                   </div>
-                  <div v-if="tempIconType === 'WHEELING'" id="wheeler" class="ma-0 pa-0">
+                  <div v-if="userStore.user.travelMethod === 'WHEELING'" id="wheeler" class="ma-0 pa-0">
                     <v-slider
                       v-model="mileage.kilometres"
                       color="green"
@@ -123,9 +123,6 @@ const form = ref(false)
 const required = (v: string) => {
   return !!v || 'Field is required'
 }
-
-// The icon on the slider changes depending on this variable. Current temp options are "RUNNING" | "WALKING" | "WHEELING"
-const tempIconType: string = 'RUNNING'
 
 const value = computed({
   get() {

--- a/client/src/components/NavbarComponents.vue
+++ b/client/src/components/NavbarComponents.vue
@@ -189,9 +189,9 @@
 
   <v-img :src="FooterBanner" width="100%" height="8" class="sticky-nav-img" cover />
 
-  <SignUpModal v-if="modalStore.isRegister"/>
+  <SignUpModal v-if="modalStore.isRegister" />
 
-  <LoginModal v-if="modalStore.isLogin"/>
+  <LoginModal v-if="modalStore.isLogin" />
   <PopupDialog
     v-model="openConfirmLogoutDialogueBox"
     title="Confirm Logout"

--- a/client/src/components/NavbarComponents.vue
+++ b/client/src/components/NavbarComponents.vue
@@ -189,9 +189,9 @@
 
   <v-img :src="FooterBanner" width="100%" height="8" class="sticky-nav-img" cover />
 
-  <SignUpModal />
+  <SignUpModal v-if="modalStore.isRegister"/>
 
-  <LoginModal />
+  <LoginModal v-if="modalStore.isLogin"/>
   <PopupDialog
     v-model="openConfirmLogoutDialogueBox"
     title="Confirm Logout"

--- a/server/api/users/views.py
+++ b/server/api/users/views.py
@@ -64,10 +64,10 @@ def request_reset_password(request):
     serializer = RequestResetPasswordSerializer(instance=user, data=data)
     if serializer.is_valid():
         serializer.save()
-        html_content = render_to_string('reset_password.html', {'token': user.reset_token, 'email': user.email})
+        html_content = render_to_string('reset_password.html', {'token': user.reset_token, 'username': user.username, 'email': user.email})
         send_mail(
             subject="Reset Password",
-            message=make_reset_email_message(user.email, user.reset_token),
+            message=make_reset_email_message(user.email, user.username, user.reset_token),
             from_email=settings.EMAIL_ADDRESS_FROM,
             recipient_list=[user.email],
             fail_silently=False,
@@ -105,8 +105,8 @@ def reset_password(request):
         return Response(status=400)
 
 
-def make_reset_email_message(email, token):
-    return ("We have received a request to reset the password "
+def make_reset_email_message(email, username, token):
+    return (f"Hi {username},\nWe have received a request to reset the password "
             f"for the Community Spirit Foundation account associated with {email}. "
             "No changes have been made to your account yet.\n"
             "If you did make this request, you should see a field in which to enter a token. "

--- a/server/templates/reset_password.html
+++ b/server/templates/reset_password.html
@@ -1,3 +1,4 @@
+<p>Hi {{ username }},</p>
 <p>We have received a request to reset the password for the Community Spirit Foundation account associated with <i>{{ email }}</i>.
     No changes have been made to your account yet.</p>
 <p>If you did make this request, you should see a field in which to enter a token. Paste the following token into the field to reset your password:</p>


### PR DESCRIPTION
## Change Summary
**[Briefly summarise the changes that you made. Just high-level stuff]**
* Included username in password reset email
* Made it so that the login modal would reset state when it was closed. Previously, if you were on the success page, there would be no way to get to the normal login screen without reloading the page
* Made the mileage modal use the correct icon for the slider

### Change Form
**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [x] The pull request title has an issue number
- [x] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

## Other Information
**[Is there anything in particular in the review that I should be aware of?]**

# Related Issue

- Resolve #171