### PR TITLE
I211 hide archived events

### DIFF
--- a/client/src/components/EventCard.vue
+++ b/client/src/components/EventCard.vue
@@ -16,7 +16,6 @@
       >
         {{ event.isPublic ? 'Official' : 'Private' }}
       </v-chip>
-      <v-chip v-if="event.isArchived"> Archived </v-chip>
     </v-card-title>
     <v-card-subtitle class="text-primaryRed font-italic"
       >{{ event.startDate }} - {{ event.endDate }}</v-card-subtitle

--- a/client/src/components/EventsModal.vue
+++ b/client/src/components/EventsModal.vue
@@ -33,7 +33,7 @@ const addEvent = () =>
         type: 'success',
         text: 'Add Event Successful'
       })
-      closeModal
+      closeModal()
     })
     .catch(() => {
       console.log
@@ -57,7 +57,7 @@ const editEvent = () => {
           type: 'success',
           text: 'Edit Event Successful'
         })
-        closeModal
+        closeModal()
       })
       .catch(() => {
         console.log
@@ -83,7 +83,7 @@ const archiveEvent = () => {
           type: 'success',
           text: 'Archive Event Successful'
         })
-        closeModal
+        closeModal()
       })
       .catch(() => {
         notify({
@@ -105,7 +105,7 @@ const deleteEvent = () => {
           type: 'success',
           text: 'Delete Event Successful'
         })
-        closeModal
+        closeModal()
       })
       .catch(() => {
         console.log

--- a/client/src/stores/event.ts
+++ b/client/src/stores/event.ts
@@ -26,7 +26,7 @@ export const useEventStore = defineStore('event', {
         const { status } = await server.put(`event/update/${event.eventId}`, snakify(event))
         if (status == 200) {
           if (event.isArchived) {
-            this.events.splice(index,1)
+            this.events.splice(index, 1)
           } else {
             this.events[index] = event
           }

--- a/client/src/stores/event.ts
+++ b/client/src/stores/event.ts
@@ -24,7 +24,13 @@ export const useEventStore = defineStore('event', {
       const index = this.events.findIndex((e) => e.eventId == event.eventId && !e.isPublic)
       if (index > -1) {
         const { status } = await server.put(`event/update/${event.eventId}`, snakify(event))
-        if (status == 200) this.events[index] = event
+        if (status == 200) {
+          if (event.isArchived) {
+            this.events.splice(index,1)
+          } else {
+            this.events[index] = event
+          }
+        }
       }
     },
     async deleteEvent(eventId: Event['eventId']) {

--- a/server/api/event/test_authenticated.py
+++ b/server/api/event/test_authenticated.py
@@ -74,7 +74,7 @@ class EventTests(APITestCase):
     def test_get_events(self):
         token = self.get_token()
         self.client.credentials(HTTP_AUTHORIZATION='Bearer {0}'.format(token))
-        all_event = Event.objects.all()
+        all_event = Event.objects.filter(is_archived=False)
         response = self.client.get(reverse("event:get-events"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data_count = 0

--- a/server/api/event/views.py
+++ b/server/api/event/views.py
@@ -24,15 +24,15 @@ def create_event(request):
 def get_events(request):
     if request.user.is_authenticated is True:
         if (request.user.team_id is not None):
-            events = Event.objects.filter(Q(is_public=True) | Q(team_id=request.user.team_id))
+            events = Event.objects.filter((Q(is_public=True) | Q(team_id=request.user.team_id)) & Q(is_archived=False))
             team_serializer = EventSerialiser(events, many=True)
             return Response(team_serializer.data)
         else:
-            events = Event.objects.filter(is_public=True)
+            events = Event.objects.filter(Q(is_public=True) & Q(is_archived=False))
             serializer = EventSerialiser(events, many=True)
             return Response(serializer.data)
     else:
-        events = Event.objects.filter(is_public=True)
+        events = Event.objects.filter(Q(is_public=True) & Q(is_archived=False))
         limited_serializer = EventSerialiser(events, many=True)
         return Response(limited_serializer.data)
 


### PR DESCRIPTION
## Change Summary

**[Briefly summarise the changes that you made. Just high-level stuff]**
* The get_events() view now only returns unarchived events
* Got rid of the archived chips
* Added some missing "()" to EventsModal.vue, so the modal now closes when a button is pressed
* When an event is archived, it is deleted from the list of events in the store

### Change Form

**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [x] The pull request title has an issue number
- [x] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

## Other Information

**[Is there anything in particular in the review that I should be aware of?]**


# Related Issue

- Resolve #211