### PR TITLE
set team admin to false when team is deleted

### DIFF
--- a/server/api/team/views.py
+++ b/server/api/team/views.py
@@ -65,4 +65,7 @@ def delete_team(request, team_id):
             return Response("User is not authorised to delete this team", status=403)
         else:
             team.delete()
+            request.user.team_admin = False
+            request.user.team_id = None
+            request.user.save()
             return Response("Team successfully deleted", status=200)


### PR DESCRIPTION
## Change Summary

**[Briefly summarise the changes that you made. Just high-level stuff]**
* team_admin field is set to false when team is deleted
* For some reason I had to set the team_id foreign key to null as well. I expected that to be done automatically since we have ondelete=models.SET_NULL

### Change Form

**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [x] The pull request title has an issue number
- [x] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

## Other Information

**[Is there anything in particular in the review that I should be aware of?]**


# Related Issue

- Resolve #215