### PR TITLE
i254-status_notifications_for_sign-up_modal_not_styled_correctly_on_firefox

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -12,7 +12,7 @@ import { RouterView } from 'vue-router'
     classes="csf-notification"
     position="bottom right"
     width="350px"
-    duration="3"
+    duration="600"
     closeOnClick="True"
   />
 </template>
@@ -153,23 +153,15 @@ body {
   margin-right: 3%;
   font-size: 14px;
   color: #ffffff;
+  background: #44a4fc;
+  text-align: center !important;
+}
 
-  .notification-title {
-    text-align: center;
-  }
-
-  .notification-content {
-    text-align: center;
-  }
-
-  &.success {
+.csf-notification.success {
     background: rgb(0, 157, 79);
-    border-left-color: rgb(0, 157, 79);
   }
 
-  &.error {
-    background: rgb(237, 28, 36);
-    border-left-color: rgb(237, 28, 36);
-  }
+.csf-notification.error {
+  background: rgb(237, 28, 36);
 }
 </style>

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -12,7 +12,6 @@ import { RouterView } from 'vue-router'
     classes="csf-notification"
     position="bottom right"
     width="350px"
-    duration="600"
     closeOnClick="True"
   />
 </template>
@@ -158,8 +157,8 @@ body {
 }
 
 .csf-notification.success {
-    background: rgb(0, 157, 79);
-  }
+  background: rgb(0, 157, 79);
+}
 
 .csf-notification.error {
   background: rgb(237, 28, 36);


### PR DESCRIPTION
## Change Summary

- adjusted sign up and email notification css to work on firefox
- removed duration tag as it is same as default duration
- removed unnecessary specified border-left colours

### Change Form

**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [x] The pull request title has an issue number
- [x] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

## Other Information

shout out to chatgpt for helping me to identify that the & selector is not recognised for normal css


# Related Issue

- Resolve #254